### PR TITLE
Z80 debugger UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ zig-*/
 .zig-*/
 .vscode/
 .cursor
-.claude/settings.local.json
+/.claude

--- a/emus/kc85/kc85.zig
+++ b/emus/kc85/kc85.zig
@@ -7,6 +7,7 @@ const slog = sokol.log;
 const host = @import("chipz").host;
 const kc85 = @import("chipz").systems.kc85;
 const ui = @import("chipz").ui;
+const clock = @import("chipz").common.clock;
 
 const ig = @import("cimgui");
 const simgui = sokol.imgui;
@@ -125,6 +126,8 @@ const UI_Z80CTC_Pins = [_]UI_CHIP.Pin{
     .{ .name = "CT3", .slot = 25, .mask = kc85.Z80CTC.CLKTRG3 },
 };
 const UI_MEMMAP = ui.ui_memmap.MemMap;
+const UI_DASM = ui.ui_dasm.Dasm;
+const UI_DBG = ui.ui_dbg.Type(.{ .bus = kc85.Bus, .cpu = kc85.Z80 });
 // a once-trigger for loading a file after booting has finished
 var file_loaded = host.time.Once.init(switch (model) {
     .KC852, .KC853 => 8 * 1000 * 1000,
@@ -137,6 +140,13 @@ var ui_z80: UI_Z80 = undefined;
 var ui_z80pio: UI_Z80PIO = undefined;
 var ui_z80ctc: UI_Z80CTC = undefined;
 var ui_memmap: UI_MEMMAP = undefined;
+var ui_dasm: [2]UI_DASM = undefined;
+var ui_dbg_win: UI_DBG = undefined;
+
+fn memRead(addr: u16, userdata: ?*anyopaque) u8 {
+    const s: *KC85 = @ptrCast(@alignCast(userdata));
+    return s.mem.rd(addr);
+}
 
 export fn init() void {
     host.audio.init(.{});
@@ -195,6 +205,31 @@ export fn init() void {
         .title = "Memory Map",
         .origin = start,
     });
+    start.x += d.x;
+    start.y += d.y;
+    ui_dasm[0].initInPlace(.{
+        .title = "Disassembler #1",
+        .read_cb = memRead,
+        .userdata = &sys,
+        .origin = start,
+    });
+    start.x += d.x;
+    start.y += d.y;
+    ui_dasm[1].initInPlace(.{
+        .title = "Disassembler #2",
+        .read_cb = memRead,
+        .userdata = &sys,
+        .origin = start,
+    });
+    start.x += d.x;
+    start.y += d.y;
+    ui_dbg_win.initInPlace(.{
+        .title = "CPU Debugger",
+        .cpu = &sys.cpu,
+        .read_cb = memRead,
+        .userdata = &sys,
+        .origin = start,
+    });
 
     host.gfx.init(.{ .display = sys.displayInfo() });
 
@@ -217,6 +252,24 @@ export fn init() void {
 
 fn renderGUI() void {
     simgui.render();
+}
+
+fn execWithDebug(frame_time_us: u32) u32 {
+    if (ui_dbg_win.isStopped()) {
+        // Paused: don't advance emulation
+        return 0;
+    } else if (ui_dbg_win.needsTickDebug()) {
+        // Tick-by-tick for step mode or active breakpoints
+        const max_ticks = clock.microSecondsToTicks(KC85.FREQUENCY, frame_time_us);
+        var ticks: u32 = 0;
+        while (ticks < max_ticks) : (ticks += 1) {
+            sys.bus = sys.tick(sys.bus);
+            if (ui_dbg_win.tick(sys.bus)) break;
+        }
+        return ticks;
+    } else {
+        return sys.exec(frame_time_us);
+    }
 }
 
 fn uiDrawMenu() void {
@@ -256,41 +309,20 @@ fn uiDrawMenu() void {
             ig.igEndMenu();
         }
         if (ig.igBeginMenu("Debug")) {
-            if (ig.igMenuItem("CPU Debugger (TODO)")) {
-                // TODO: open window
+            if (ig.igMenuItem("CPU Debugger")) {
+                ui_dbg_win.open = true;
             }
-            if (ig.igMenuItem("Breakpoints (TODO)")) {
-                // TODO: open window
-            }
-            if (ig.igBeginMenu("Memory Editor (TODO)")) {
+            if (ig.igBeginMenu("Disassembler")) {
                 if (ig.igMenuItem("Window #1")) {
-                    // TODO: open window
+                    ui_dasm[0].open = true;
                 }
                 if (ig.igMenuItem("Window #2")) {
-                    // TODO: open window
-                }
-                if (ig.igMenuItem("Window #3")) {
-                    // TODO: open window
-                }
-                if (ig.igMenuItem("Window #4")) {
-                    // TODO: open window
+                    ui_dasm[1].open = true;
                 }
                 ig.igEndMenu();
             }
-            if (ig.igBeginMenu("Disassembler (TODO)")) {
-                if (ig.igMenuItem("Window #1")) {
-                    // TODO: open window
-                }
-                if (ig.igMenuItem("Window #2")) {
-                    // TODO: open window
-                }
-                if (ig.igMenuItem("Window #3")) {
-                    // TODO: open window
-                }
-                if (ig.igMenuItem("Window #4")) {
-                    // TODO: open window
-                }
-                ig.igEndMenu();
+            if (ig.igMenuItem("Memory Editor (TODO)")) {
+                // TODO: open memory editor window
             }
             ig.igEndMenu();
         }
@@ -302,7 +334,7 @@ export fn frame() void {
     const frame_time_us = host.time.frameTime();
     host.prof.pushMicroSeconds(.FRAME, frame_time_us);
     host.time.emuStart();
-    const num_ticks = sys.exec(frame_time_us);
+    const num_ticks = execWithDebug(frame_time_us);
     host.prof.pushMicroSeconds(.EMU, host.time.emuEnd());
 
     // call simgui.newFrame() before any ImGui calls
@@ -318,6 +350,9 @@ export fn frame() void {
     ui_z80pio.draw(sys.bus);
     ui_z80ctc.draw(sys.bus);
     ui_memmap.draw();
+    ui_dasm[0].draw();
+    ui_dasm[1].draw();
+    ui_dbg_win.draw(sys.bus);
 
     host.gfx.draw(.{
         .display = sys.displayInfo(),

--- a/src/chips/chips.zig
+++ b/src/chips/chips.zig
@@ -3,3 +3,4 @@ pub const z80ctc = @import("z80ctc.zig");
 pub const z80pio = @import("z80pio.zig");
 pub const ay3891 = @import("ay3891.zig");
 pub const intel8255 = @import("intel8255.zig");
+pub const z80dasm = @import("z80dasm.zig");

--- a/src/chips/z80dasm.zig
+++ b/src/chips/z80dasm.zig
@@ -1,0 +1,517 @@
+//! Z80 disassembler.
+//!
+//! Zig port of the z80dasm.h from the chips project by Andre Weissflog.
+//! Decoding strategy: http://www.z80.info/decoding.htm
+const std = @import("std");
+
+pub const MAX_MNEMONIC_LEN = 32;
+pub const MAX_BYTES = 4;
+
+pub const Result = struct {
+    next_pc: u16,
+    num_bytes: u8,
+    mnemonic: [MAX_MNEMONIC_LEN]u8 = [_]u8{0} ** MAX_MNEMONIC_LEN,
+    mnemonic_len: u8,
+
+    pub fn mnemonicSlice(self: *const Result) []const u8 {
+        return self.mnemonic[0..self.mnemonic_len];
+    }
+};
+
+// Register name tables
+const r_hl = [_][]const u8{ "B", "C", "D", "E", "H", "L", "(HL)", "A" };
+const r_ix = [_][]const u8{ "B", "C", "D", "E", "IXH", "IXL", "(IX", "A" };
+const r_iy = [_][]const u8{ "B", "C", "D", "E", "IYH", "IYL", "(IY", "A" };
+const rp_hl = [_][]const u8{ "BC", "DE", "HL", "SP" };
+const rp_ix = [_][]const u8{ "BC", "DE", "IX", "SP" };
+const rp_iy = [_][]const u8{ "BC", "DE", "IY", "SP" };
+const rp2_hl = [_][]const u8{ "BC", "DE", "HL", "AF" };
+const rp2_ix = [_][]const u8{ "BC", "DE", "IX", "AF" };
+const rp2_iy = [_][]const u8{ "BC", "DE", "IY", "AF" };
+const cc = [_][]const u8{ "NZ", "Z", "NC", "C", "PO", "PE", "P", "M" };
+const alu = [_][]const u8{ "ADD A,", "ADC A,", "SUB ", "SBC A,", "AND ", "XOR ", "OR ", "CP " };
+const rot = [_][]const u8{ "RLC ", "RRC ", "RL ", "RR ", "SLA ", "SRA ", "SLL ", "SRL " };
+const x0z7 = [_][]const u8{ "RLCA", "RRCA", "RLA", "RRA", "DAA", "CPL", "SCF", "CCF" };
+const edx1z7 = [_][]const u8{ "LD I,A", "LD R,A", "LD A,I", "LD A,R", "RRD", "RLD", "NOP (ED)", "NOP (ED)" };
+const im_modes = [_][]const u8{ "0", "0", "1", "2", "0", "0", "1", "2" };
+const bli = [4][4][]const u8{
+    .{ "LDI", "CPI", "INI", "OUTI" },
+    .{ "LDD", "CPD", "IND", "OUTD" },
+    .{ "LDIR", "CPIR", "INIR", "OTIR" },
+    .{ "LDDR", "CPDR", "INDR", "OTDR" },
+};
+
+const Ctx = struct {
+    pc: u16,
+    num_bytes: u8,
+    read_fn: *const fn (u16, ?*anyopaque) u8,
+    user_data: ?*anyopaque,
+    buf: [MAX_MNEMONIC_LEN]u8,
+    buf_pos: u8,
+    pre: u8, // prefix byte: 0, 0xDD, or 0xFD
+
+    fn fetchU8(self: *Ctx) u8 {
+        const v = self.read_fn(self.pc, self.user_data);
+        self.pc +%= 1;
+        self.num_bytes += 1;
+        return v;
+    }
+
+    fn fetchI8(self: *Ctx) i8 {
+        return @bitCast(self.fetchU8());
+    }
+
+    fn fetchU16(self: *Ctx) u16 {
+        const lo: u16 = self.fetchU8();
+        const hi: u16 = self.fetchU8();
+        return lo | (hi << 8);
+    }
+
+    fn chr(self: *Ctx, c: u8) void {
+        if (self.buf_pos < MAX_MNEMONIC_LEN) {
+            self.buf[self.buf_pos] = c;
+            self.buf_pos += 1;
+        }
+    }
+
+    fn str(self: *Ctx, s: []const u8) void {
+        for (s) |c| self.chr(c);
+    }
+
+    // output signed 8-bit offset as decimal (+d or -d)
+    fn strD8(self: *Ctx, val: i8) void {
+        if (val < 0) {
+            self.chr('-');
+            const v: u8 = @intCast(-@as(i16, val));
+            if (v >= 100) self.chr('1');
+            const v2: u8 = if (v >= 100) v - 100 else v;
+            if (v2 / 10 != 0) self.chr('0' + v2 / 10);
+            self.chr('0' + v2 % 10);
+        } else {
+            self.chr('+');
+            const v: u8 = @intCast(val);
+            if (v >= 100) self.chr('1');
+            const v2: u8 = if (v >= 100) v - 100 else v;
+            if (v2 / 10 != 0) self.chr('0' + v2 / 10);
+            self.chr('0' + v2 % 10);
+        }
+    }
+
+    // output unsigned 8-bit value as hex (e.g. "1Fh")
+    fn strU8(self: *Ctx, val: u8) void {
+        const hex = "0123456789ABCDEF";
+        self.chr(hex[(val >> 4) & 0xF]);
+        self.chr(hex[val & 0xF]);
+        self.chr('h');
+    }
+
+    // output unsigned 16-bit value as hex (e.g. "1234h")
+    fn strU16(self: *Ctx, val: u16) void {
+        const hex = "0123456789ABCDEF";
+        self.chr(hex[(val >> 12) & 0xF]);
+        self.chr(hex[(val >> 8) & 0xF]);
+        self.chr(hex[(val >> 4) & 0xF]);
+        self.chr(hex[val & 0xF]);
+        self.chr('h');
+    }
+
+    // (HL) or (IX+d) or (IY+d) — fetches the displacement byte if prefixed
+    fn mem(self: *Ctx, regs: []const []const u8) void {
+        self.str(regs[6]);
+        if (self.pre != 0) {
+            const d = self.fetchI8();
+            self.strD8(d);
+            self.chr(')');
+        }
+    }
+
+    // (HL) or (IX+d) or (IY+d) — with an already-fetched displacement byte
+    fn memD(self: *Ctx, d: i8, regs: []const []const u8) void {
+        self.str(regs[6]);
+        if (self.pre != 0) {
+            self.strD8(d);
+            self.chr(')');
+        }
+    }
+
+    // register or memory reference
+    fn memR(self: *Ctx, i: u3, regs: []const []const u8) void {
+        if (i == 6) {
+            self.mem(regs);
+        } else {
+            self.str(regs[i]);
+        }
+    }
+
+    // register or memory reference with pre-fetched displacement
+    fn memRd(self: *Ctx, i: u3, d: i8, regs: []const []const u8) void {
+        self.str(regs[i]);
+        if (i == 6 and self.pre != 0) {
+            self.strD8(d);
+            self.chr(')');
+        }
+    }
+
+    fn r(self: *Ctx) []const []const u8 {
+        return switch (self.pre) {
+            0xDD => &r_ix,
+            0xFD => &r_iy,
+            else => &r_hl,
+        };
+    }
+
+    fn rp(self: *Ctx) []const []const u8 {
+        return switch (self.pre) {
+            0xDD => &rp_ix,
+            0xFD => &rp_iy,
+            else => &rp_hl,
+        };
+    }
+
+    fn rp2(self: *Ctx) []const []const u8 {
+        return switch (self.pre) {
+            0xDD => &rp2_ix,
+            0xFD => &rp2_iy,
+            else => &rp2_hl,
+        };
+    }
+};
+
+/// Disassemble one Z80 instruction starting at `pc`.
+/// `read_fn(addr, user_data)` returns the byte at the given address.
+/// Returns the next PC and the disassembled mnemonic string.
+pub fn op(pc: u16, read_fn: *const fn (u16, ?*anyopaque) u8, user_data: ?*anyopaque) Result {
+    var ctx = Ctx{
+        .pc = pc,
+        .num_bytes = 0,
+        .read_fn = read_fn,
+        .user_data = user_data,
+        .buf = [_]u8{0} ** MAX_MNEMONIC_LEN,
+        .buf_pos = 0,
+        .pre = 0,
+    };
+    disasm(&ctx);
+    return Result{
+        .next_pc = ctx.pc,
+        .num_bytes = ctx.num_bytes,
+        .mnemonic = ctx.buf,
+        .mnemonic_len = ctx.buf_pos,
+    };
+}
+
+fn disasm(ctx: *Ctx) void {
+    var byte = ctx.fetchU8();
+
+    // handle DD/FD prefix
+    if (byte == 0xDD or byte == 0xFD) {
+        ctx.pre = byte;
+        byte = ctx.fetchU8();
+        if (byte == 0xED) {
+            ctx.pre = 0; // ED after prefix cancels prefix
+        }
+    }
+
+    const x: u2 = @truncate(byte >> 6);
+    const y: u3 = @truncate((byte >> 3) & 7);
+    const z: u3 = @truncate(byte & 7);
+    const p: u2 = @truncate(y >> 1);
+    const q: u1 = @truncate(y & 1);
+
+    if (x == 1) {
+        // 8-bit load block
+        if (y == 6) {
+            if (z == 6) {
+                ctx.str("HALT");
+            } else {
+                // LD (HL),r / LD (IX+d),r / LD (IY+d),r
+                ctx.str("LD ");
+                ctx.mem(ctx.r());
+                ctx.chr(',');
+                if (ctx.pre != 0 and (z == 4 or z == 5)) {
+                    ctx.str(r_hl[z]);
+                } else {
+                    ctx.str(ctx.r()[z]);
+                }
+            }
+        } else if (z == 6) {
+            // LD r,(HL) / LD r,(IX+d) / LD r,(IY+d)
+            ctx.str("LD ");
+            if (ctx.pre != 0 and (y == 4 or y == 5)) {
+                ctx.str(r_hl[y]);
+            } else {
+                ctx.str(ctx.r()[y]);
+            }
+            ctx.chr(',');
+            ctx.mem(ctx.r());
+        } else {
+            // regular LD r,s
+            ctx.str("LD ");
+            ctx.str(ctx.r()[y]);
+            ctx.chr(',');
+            ctx.str(ctx.r()[z]);
+        }
+    } else if (x == 2) {
+        // 8-bit ALU block
+        ctx.str(alu[y]);
+        ctx.memR(z, ctx.r());
+    } else if (x == 0) {
+        switch (z) {
+            0 => switch (y) {
+                0 => ctx.str("NOP"),
+                1 => ctx.str("EX AF,AF'"),
+                2 => {
+                    ctx.str("DJNZ ");
+                    const d = ctx.fetchI8();
+                    ctx.strU16(ctx.pc +% @as(u16, @bitCast(@as(i16, d))));
+                },
+                3 => {
+                    ctx.str("JR ");
+                    const d = ctx.fetchI8();
+                    ctx.strU16(ctx.pc +% @as(u16, @bitCast(@as(i16, d))));
+                },
+                else => {
+                    ctx.str("JR ");
+                    ctx.str(cc[y - 4]);
+                    ctx.chr(',');
+                    const d = ctx.fetchI8();
+                    ctx.strU16(ctx.pc +% @as(u16, @bitCast(@as(i16, d))));
+                },
+            },
+            1 => {
+                if (q == 0) {
+                    ctx.str("LD ");
+                    ctx.str(ctx.rp()[p]);
+                    ctx.chr(',');
+                    ctx.strU16(ctx.fetchU16());
+                } else {
+                    ctx.str("ADD ");
+                    ctx.str(ctx.rp()[2]);
+                    ctx.chr(',');
+                    ctx.str(ctx.rp()[p]);
+                }
+            },
+            2 => {
+                ctx.str("LD ");
+                switch (y) {
+                    0 => ctx.str("(BC),A"),
+                    1 => ctx.str("A,(BC)"),
+                    2 => ctx.str("(DE),A"),
+                    3 => ctx.str("A,(DE)"),
+                    4 => {
+                        ctx.chr('(');
+                        ctx.strU16(ctx.fetchU16());
+                        ctx.str("),");
+                        ctx.str(ctx.rp()[2]);
+                    },
+                    5 => {
+                        ctx.str(ctx.rp()[2]);
+                        ctx.str(",(");
+                        ctx.strU16(ctx.fetchU16());
+                        ctx.chr(')');
+                    },
+                    6 => {
+                        ctx.chr('(');
+                        ctx.strU16(ctx.fetchU16());
+                        ctx.str("),A");
+                    },
+                    7 => {
+                        ctx.str("A,(");
+                        ctx.strU16(ctx.fetchU16());
+                        ctx.chr(')');
+                    },
+                }
+            },
+            3 => {
+                ctx.str(if (q == 0) "INC " else "DEC ");
+                ctx.str(ctx.rp()[p]);
+            },
+            4 => {
+                ctx.str("INC ");
+                ctx.memR(y, ctx.r());
+            },
+            5 => {
+                ctx.str("DEC ");
+                ctx.memR(y, ctx.r());
+            },
+            6 => {
+                ctx.str("LD ");
+                ctx.memR(y, ctx.r());
+                ctx.chr(',');
+                ctx.strU8(ctx.fetchU8());
+            },
+            7 => ctx.str(x0z7[y]),
+        }
+    } else { // x == 3
+        switch (z) {
+            0 => {
+                ctx.str("RET ");
+                ctx.str(cc[y]);
+            },
+            1 => {
+                if (q == 0) {
+                    ctx.str("POP ");
+                    ctx.str(ctx.rp2()[p]);
+                } else {
+                    switch (p) {
+                        0 => ctx.str("RET"),
+                        1 => ctx.str("EXX"),
+                        2 => {
+                            ctx.str("JP (");
+                            ctx.str(ctx.rp()[2]);
+                            ctx.chr(')');
+                        },
+                        3 => {
+                            ctx.str("LD SP,");
+                            ctx.str(ctx.rp()[2]);
+                        },
+                    }
+                }
+            },
+            2 => {
+                ctx.str("JP ");
+                ctx.str(cc[y]);
+                ctx.chr(',');
+                ctx.strU16(ctx.fetchU16());
+            },
+            3 => {
+                switch (y) {
+                    0 => {
+                        ctx.str("JP ");
+                        ctx.strU16(ctx.fetchU16());
+                    },
+                    1 => { // CB prefix
+                        const saved_pre = ctx.pre;
+                        var d: i8 = 0;
+                        if (saved_pre != 0) {
+                            d = ctx.fetchI8();
+                        }
+                        const cb_op = ctx.fetchU8();
+                        const cx: u2 = @truncate(cb_op >> 6);
+                        const cy: u3 = @truncate((cb_op >> 3) & 7);
+                        const cz: u3 = @truncate(cb_op & 7);
+                        if (cx == 0) {
+                            ctx.str(rot[cy]);
+                            ctx.memRd(cz, d, ctx.r());
+                        } else {
+                            if (cx == 1) ctx.str("BIT ") else if (cx == 2) ctx.str("RES ") else ctx.str("SET ");
+                            ctx.chr('0' + @as(u8, cy));
+                            if (saved_pre != 0) {
+                                ctx.chr(',');
+                                ctx.memD(d, ctx.r());
+                            }
+                            if (saved_pre == 0 or cz != 6) {
+                                ctx.chr(',');
+                                ctx.str(ctx.r()[cz]);
+                            }
+                        }
+                    },
+                    2 => {
+                        ctx.str("OUT (");
+                        ctx.strU8(ctx.fetchU8());
+                        ctx.str("),A");
+                    },
+                    3 => {
+                        ctx.str("IN A,(");
+                        ctx.strU8(ctx.fetchU8());
+                        ctx.chr(')');
+                    },
+                    4 => {
+                        ctx.str("EX (SP),");
+                        ctx.str(ctx.rp()[2]);
+                    },
+                    5 => ctx.str("EX DE,HL"),
+                    6 => ctx.str("DI"),
+                    7 => ctx.str("EI"),
+                }
+            },
+            4 => {
+                ctx.str("CALL ");
+                ctx.str(cc[y]);
+                ctx.chr(',');
+                ctx.strU16(ctx.fetchU16());
+            },
+            5 => {
+                if (q == 0) {
+                    ctx.str("PUSH ");
+                    ctx.str(ctx.rp2()[p]);
+                } else {
+                    switch (p) {
+                        0 => {
+                            ctx.str("CALL ");
+                            ctx.strU16(ctx.fetchU16());
+                        },
+                        1 => ctx.str("DBL PREFIX"),
+                        3 => ctx.str("DBL PREFIX"),
+                        2 => { // ED prefix
+                            const ed_op = ctx.fetchU8();
+                            const ex: u2 = @truncate(ed_op >> 6);
+                            const ey: u3 = @truncate((ed_op >> 3) & 7);
+                            const ez: u3 = @truncate(ed_op & 7);
+                            const ep: u2 = @truncate(ey >> 1);
+                            const eq: u1 = @truncate(ey & 1);
+                            if (ex == 0 or ex == 3) {
+                                ctx.str("NOP (ED)");
+                            } else if (ex == 2) {
+                                if (ey >= 4 and ez <= 3) {
+                                    ctx.str(bli[ey - 4][ez]);
+                                } else {
+                                    ctx.str("NOP (ED)");
+                                }
+                            } else { // ex == 1
+                                switch (ez) {
+                                    0 => {
+                                        ctx.str("IN ");
+                                        if (ey != 6) {
+                                            ctx.str(r_hl[ey]);
+                                            ctx.chr(',');
+                                        }
+                                        ctx.str("(C)");
+                                    },
+                                    1 => {
+                                        ctx.str("OUT (C),");
+                                        ctx.str(if (ey == 6) "0" else r_hl[ey]);
+                                    },
+                                    2 => {
+                                        ctx.str(if (eq == 0) "SBC" else "ADC");
+                                        ctx.str(" HL,");
+                                        ctx.str(rp_hl[ep]);
+                                    },
+                                    3 => {
+                                        ctx.str("LD ");
+                                        if (eq == 0) {
+                                            ctx.chr('(');
+                                            ctx.strU16(ctx.fetchU16());
+                                            ctx.str("),");
+                                            ctx.str(rp_hl[ep]);
+                                        } else {
+                                            ctx.str(rp_hl[ep]);
+                                            ctx.str(",(");
+                                            ctx.strU16(ctx.fetchU16());
+                                            ctx.chr(')');
+                                        }
+                                    },
+                                    4 => ctx.str("NEG"),
+                                    5 => ctx.str(if (ey == 1) "RETI" else "RETN"),
+                                    6 => {
+                                        ctx.str("IM ");
+                                        ctx.str(im_modes[ey]);
+                                    },
+                                    7 => ctx.str(edx1z7[ey]),
+                                }
+                            }
+                        },
+                    }
+                }
+            },
+            6 => {
+                // ALU n
+                ctx.str(alu[y]);
+                ctx.strU8(ctx.fetchU8());
+            },
+            7 => {
+                ctx.str("RST ");
+                ctx.strU8(@as(u8, y) * 8);
+            },
+        }
+    }
+}

--- a/src/ui/ui.zig
+++ b/src/ui/ui.zig
@@ -6,3 +6,5 @@ pub const ui_z80pio = @import("ui_z80pio.zig");
 pub const ui_z80ctc = @import("ui_z80ctc.zig");
 pub const ui_intel8255 = @import("ui_intel8255.zig");
 pub const ui_memmap = @import("ui_memmap.zig");
+pub const ui_dasm = @import("ui_dasm.zig");
+pub const ui_dbg = @import("ui_dbg.zig");

--- a/src/ui/ui_dasm.zig
+++ b/src/ui/ui_dasm.zig
@@ -1,0 +1,280 @@
+//! Z80 disassembler UI window.
+const std = @import("std");
+const z80dasm = @import("chips").z80dasm;
+const ig = @import("cimgui");
+const ui_settings = @import("ui_settings.zig");
+
+pub const NUM_LINES = 512;
+pub const STACK_MAX = 128;
+
+pub const Dasm = struct {
+    const Self = @This();
+
+    pub const Options = struct {
+        title: []const u8,
+        read_cb: *const fn (addr: u16, userdata: ?*anyopaque) u8,
+        userdata: ?*anyopaque,
+        origin: ig.ImVec2,
+        size: ig.ImVec2 = .{},
+        open: bool = false,
+    };
+
+    title: []const u8,
+    read_cb: *const fn (addr: u16, userdata: ?*anyopaque) u8,
+    userdata: ?*anyopaque,
+    origin: ig.ImVec2,
+    size: ig.ImVec2,
+    open: bool,
+    last_open: bool,
+    valid: bool,
+    start_addr: u16,
+    highlight_addr: u16,
+    highlight_valid: bool,
+    stack: [STACK_MAX]u16,
+    stack_num: u8,
+    stack_pos: u8,
+
+    pub fn initInPlace(self: *Self, opts: Options) void {
+        self.* = .{
+            .title = opts.title,
+            .read_cb = opts.read_cb,
+            .userdata = opts.userdata,
+            .origin = opts.origin,
+            .size = .{
+                .x = if (opts.size.x == 0) 400 else opts.size.x,
+                .y = if (opts.size.y == 0) 256 else opts.size.y,
+            },
+            .open = opts.open,
+            .last_open = opts.open,
+            .valid = true,
+            .start_addr = 0,
+            .highlight_addr = 0,
+            .highlight_valid = false,
+            .stack = [_]u16{0} ** STACK_MAX,
+            .stack_num = 0,
+            .stack_pos = 0,
+        };
+    }
+
+    pub fn discard(self: *Self) void {
+        self.valid = false;
+    }
+
+    fn goto(self: *Self, addr: u16) void {
+        self.start_addr = addr;
+    }
+
+    fn stackPush(self: *Self, addr: u16) void {
+        if (self.stack_num < STACK_MAX) {
+            if (self.stack_num > 0 and addr == self.stack[self.stack_num - 1]) return;
+            self.stack_pos = self.stack_num;
+            self.stack[self.stack_num] = addr;
+            self.stack_num += 1;
+        }
+    }
+
+    fn stackBack(self: *Self) ?u16 {
+        if (self.stack_num == 0) return null;
+        const addr = self.stack[self.stack_pos];
+        if (self.stack_pos > 0) self.stack_pos -= 1;
+        return addr;
+    }
+
+    fn jumpTarget(next_addr: u16, bytes: []const u8) ?u16 {
+        if (bytes.len == 3) {
+            switch (bytes[0]) {
+                0xCD, 0xDC, 0xFC, 0xD4, 0xC4, 0xF4, 0xEC, 0xE4, 0xCC,
+                0xC3, 0xDA, 0xFA, 0xD2, 0xC2, 0xF2, 0xEA, 0xE2, 0xCA,
+                => return (@as(u16, bytes[2]) << 8) | bytes[1],
+                else => {},
+            }
+        }
+        if (bytes.len == 2) {
+            switch (bytes[0]) {
+                0x10, 0x18, 0x38, 0x30, 0x20, 0x28 => {
+                    const off: i16 = @as(i8, @bitCast(bytes[1]));
+                    return next_addr +% @as(u16, @bitCast(off));
+                },
+                else => {},
+            }
+        }
+        if (bytes.len == 1) {
+            return switch (bytes[0]) {
+                0xC7 => 0x00,
+                0xCF => 0x08,
+                0xD7 => 0x10,
+                0xDF => 0x18,
+                0xE7 => 0x20,
+                0xEF => 0x28,
+                0xF7 => 0x30,
+                0xFF => 0x38,
+                else => null,
+            };
+        }
+        return null;
+    }
+
+    fn drawStack(self: *Self) void {
+        _ = ig.igBeginChild("##dasm_stack", .{ .x = 72, .y = 0 }, ig.ImGuiChildFlags_Borders, ig.ImGuiWindowFlags_None);
+        if (ig.igButton("Clear")) {
+            self.stack_num = 0;
+        }
+        if (ig.igBeginListBox("##stack", .{ .x = -1, .y = -1 })) {
+            var i: usize = 0;
+            while (i < self.stack_num) : (i += 1) {
+                var buf: [6]u8 = undefined;
+                const s = std.fmt.bufPrint(&buf, "{X:0>4}", .{self.stack[i]}) catch unreachable;
+                buf[s.len] = 0;
+                ig.igPushIDInt(@intCast(i));
+                if (ig.igSelectableEx(&buf, i == self.stack_pos, ig.ImGuiSelectableFlags_None, .{})) {
+                    self.stack_pos = @intCast(i);
+                    self.goto(self.stack[i]);
+                }
+                if (ig.igIsItemHovered(ig.ImGuiHoveredFlags_None)) {
+                    var tip: [16]u8 = undefined;
+                    const ts = std.fmt.bufPrint(&tip, "Goto {X:0>4}\x00", .{self.stack[i]}) catch unreachable;
+                    _ = ts;
+                    ig.igSetTooltip(&tip);
+                    self.highlight_addr = self.stack[i];
+                    self.highlight_valid = true;
+                }
+                ig.igPopID();
+            }
+            ig.igEndListBox();
+        }
+        ig.igEndChild();
+    }
+
+    fn drawDisasm(self: *Self) void {
+        _ = ig.igBeginChild("##dasm_box", .{ .x = 0, .y = 0 }, ig.ImGuiChildFlags_Borders, ig.ImGuiWindowFlags_None);
+
+        // Address input
+        var addr_val: u16 = self.start_addr;
+        ig.igSetNextItemWidth(60);
+        if (ig.igInputScalarEx("##addr", ig.ImGuiDataType_U16, &addr_val, null, null, "%04X", ig.ImGuiInputTextFlags_CharsHexadecimal)) {
+            self.start_addr = addr_val;
+        }
+        ig.igSameLine();
+        if (ig.igArrowButton("##back", ig.ImGuiDir_Left)) {
+            if (self.stackBack()) |a| self.goto(a);
+        }
+        if (ig.igIsItemHovered(ig.ImGuiHoveredFlags_None) and self.stack_num > 0) {
+            var tip: [16]u8 = undefined;
+            const ts = std.fmt.bufPrint(&tip, "Goto {X:0>4}\x00", .{self.stack[self.stack_pos]}) catch unreachable;
+            _ = ts;
+            ig.igSetTooltip(&tip);
+        }
+
+        _ = ig.igBeginChild("##dasm_inner", .{ .x = 0, .y = 0 }, ig.ImGuiChildFlags_None, ig.ImGuiWindowFlags_None);
+        ig.igPushStyleVarImVec2(ig.ImGuiStyleVar_FramePadding, .{ .x = 0, .y = 0 });
+        ig.igPushStyleVarImVec2(ig.ImGuiStyleVar_ItemSpacing, .{ .x = 0, .y = 0 });
+
+        const line_height = ig.igGetTextLineHeight();
+        const glyph_width = ig.igCalcTextSize("F").x;
+        const cell_width = 3 * glyph_width;
+
+        var clipper: ig.ImGuiListClipper = .{};
+        ig.ImGuiListClipper_Begin(&clipper, NUM_LINES, line_height);
+        _ = ig.ImGuiListClipper_Step(&clipper);
+
+        // Advance to DisplayStart
+        var cur_addr: u16 = self.start_addr;
+        var line_i: i32 = 0;
+        while (line_i < clipper.DisplayStart) : (line_i += 1) {
+            const res = z80dasm.op(cur_addr, self.read_cb, self.userdata);
+            cur_addr = res.next_pc;
+        }
+
+        // Draw visible lines
+        while (line_i < clipper.DisplayEnd) : (line_i += 1) {
+            const op_addr = cur_addr;
+            const res = z80dasm.op(cur_addr, self.read_cb, self.userdata);
+            cur_addr = res.next_pc;
+
+            var highlight = false;
+            if (self.highlight_valid and self.highlight_addr == op_addr) {
+                ig.igPushStyleColor(ig.ImGuiCol_Text, 0xFF30FF30);
+                highlight = true;
+            }
+
+            // Address
+            var addr_buf: [8]u8 = undefined;
+            const addr_s = std.fmt.bufPrint(&addr_buf, "{X:0>4}: \x00", .{op_addr}) catch unreachable;
+            _ = addr_s;
+            ig.igTextUnformatted(&addr_buf);
+            ig.igSameLine();
+
+            // Instruction bytes
+            const line_start_x = ig.igGetCursorPosX();
+            for (0..res.num_bytes) |bi| {
+                ig.igSameLineEx(line_start_x + cell_width * @as(f32, @floatFromInt(bi)), 0);
+                var byte_buf: [4]u8 = undefined;
+                const b = self.read_cb(op_addr +% @as(u16, @intCast(bi)), self.userdata);
+                const bs = std.fmt.bufPrint(&byte_buf, "{X:0>2} \x00", .{b}) catch unreachable;
+                _ = bs;
+                ig.igTextUnformatted(&byte_buf);
+            }
+
+            // Mnemonic
+            ig.igSameLineEx(line_start_x + cell_width * 4 + glyph_width * 2, 0);
+            var mn_buf: [z80dasm.MAX_MNEMONIC_LEN + 1]u8 = undefined;
+            @memcpy(mn_buf[0..res.mnemonic_len], res.mnemonic[0..res.mnemonic_len]);
+            mn_buf[res.mnemonic_len] = 0;
+            ig.igTextUnformatted(&mn_buf);
+
+            if (highlight) ig.igPopStyleColor();
+
+            // Collect bytes for jump-target detection
+            var bytes_buf: [z80dasm.MAX_BYTES]u8 = undefined;
+            for (0..res.num_bytes) |bi| {
+                bytes_buf[bi] = self.read_cb(op_addr +% @as(u16, @intCast(bi)), self.userdata);
+            }
+            if (jumpTarget(cur_addr, bytes_buf[0..res.num_bytes])) |jt| {
+                ig.igSameLineEx(line_start_x + cell_width * 4 + glyph_width * 2 + glyph_width * 20, 0);
+                ig.igPushIDInt(line_i);
+                if (ig.igArrowButton("##jmp", ig.ImGuiDir_Right)) {
+                    ig.igSetScrollY(0);
+                    self.stackPush(op_addr);
+                    self.goto(jt);
+                }
+                if (ig.igIsItemHovered(ig.ImGuiHoveredFlags_None)) {
+                    var tip: [16]u8 = undefined;
+                    const ts = std.fmt.bufPrint(&tip, "Goto {X:0>4}\x00", .{jt}) catch unreachable;
+                    _ = ts;
+                    ig.igSetTooltip(&tip);
+                    self.highlight_addr = jt;
+                    self.highlight_valid = true;
+                }
+                ig.igPopID();
+            }
+        }
+        ig.ImGuiListClipper_End(&clipper);
+        ig.igPopStyleVarEx(2);
+        ig.igEndChild(); // ##dasm_inner
+        ig.igEndChild(); // ##dasm_box
+    }
+
+    pub fn draw(self: *Self) void {
+        if (self.open != self.last_open) self.last_open = self.open;
+        if (!self.open) return;
+
+        self.highlight_valid = false;
+
+        ig.igSetNextWindowPos(self.origin, ig.ImGuiCond_FirstUseEver);
+        ig.igSetNextWindowSize(self.size, ig.ImGuiCond_FirstUseEver);
+        if (ig.igBegin(self.title.ptr, &self.open, ig.ImGuiWindowFlags_None)) {
+            self.drawStack();
+            ig.igSameLine();
+            self.drawDisasm();
+        }
+        ig.igEnd();
+    }
+
+    pub fn saveSettings(self: *Self, settings: *ui_settings.Settings) void {
+        _ = settings.add(self.title, self.open);
+    }
+
+    pub fn loadSettings(self: *Self, settings: *const ui_settings.Settings) void {
+        self.open = settings.isOpen(self.title);
+    }
+};

--- a/src/ui/ui_dbg.zig
+++ b/src/ui/ui_dbg.zig
@@ -1,0 +1,405 @@
+//! Z80 CPU debugger UI.
+//!
+//! Shows a disassembly view centered on the current PC, with step/continue
+//! controls, breakpoints, and execution history.
+const std = @import("std");
+const z80dasm = @import("chips").z80dasm;
+const ig = @import("cimgui");
+const ui_settings = @import("ui_settings.zig");
+
+pub const MAX_BREAKPOINTS = 32;
+pub const NUM_HISTORY = 256;
+pub const NUM_DBG_LINES = 48;
+
+pub const TypeConfig = struct {
+    bus: type,
+    cpu: type,
+};
+
+pub const StepMode = enum { none, into, over };
+
+pub const Breakpoint = struct {
+    addr: u16,
+    enabled: bool,
+};
+
+pub fn Type(comptime cfg: TypeConfig) type {
+    return struct {
+        const Self = @This();
+        const Bus = cfg.bus;
+        const Z80 = cfg.cpu;
+
+        const M1_MASK = Z80.M1 | Z80.MREQ | Z80.RD;
+
+        pub const Options = struct {
+            title: []const u8,
+            cpu: *Z80,
+            read_cb: *const fn (addr: u16, userdata: ?*anyopaque) u8,
+            userdata: ?*anyopaque,
+            origin: ig.ImVec2,
+            size: ig.ImVec2 = .{},
+            open: bool = false,
+        };
+
+        const DasmLine = struct {
+            addr: u16,
+            num_bytes: u8,
+            bytes: [4]u8,
+            mnemonic: [z80dasm.MAX_MNEMONIC_LEN]u8,
+            mnemonic_len: u8,
+        };
+
+        title: []const u8,
+        cpu: *Z80,
+        read_cb: *const fn (addr: u16, userdata: ?*anyopaque) u8,
+        userdata: ?*anyopaque,
+        origin: ig.ImVec2,
+        size: ig.ImVec2,
+        open: bool,
+        last_open: bool,
+        valid: bool,
+
+        stopped: bool,
+        step_mode: StepMode,
+        cur_op_pc: u16,
+        stepover_pc: u16,
+
+        num_breakpoints: u8,
+        breakpoints: [MAX_BREAKPOINTS]Breakpoint,
+
+        history: [NUM_HISTORY]u16,
+        history_pos: u8,
+        show_history: bool,
+
+        dasm_lines: [NUM_DBG_LINES]DasmLine,
+        dasm_num_lines: u8,
+
+        pub fn initInPlace(self: *Self, opts: Options) void {
+            self.* = .{
+                .title = opts.title,
+                .cpu = opts.cpu,
+                .read_cb = opts.read_cb,
+                .userdata = opts.userdata,
+                .origin = opts.origin,
+                .size = .{
+                    .x = if (opts.size.x == 0) 460 else opts.size.x,
+                    .y = if (opts.size.y == 0) 420 else opts.size.y,
+                },
+                .open = opts.open,
+                .last_open = opts.open,
+                .valid = true,
+                .stopped = false,
+                .step_mode = .none,
+                .cur_op_pc = 0,
+                .stepover_pc = 0,
+                .num_breakpoints = 0,
+                .breakpoints = [_]Breakpoint{.{ .addr = 0, .enabled = false }} ** MAX_BREAKPOINTS,
+                .history = [_]u16{0} ** NUM_HISTORY,
+                .history_pos = 0,
+                .show_history = false,
+                .dasm_lines = undefined,
+                .dasm_num_lines = 0,
+            };
+        }
+
+        pub fn discard(self: *Self) void {
+            self.valid = false;
+        }
+
+        pub fn isStopped(self: *const Self) bool {
+            return self.stopped;
+        }
+
+        /// Returns true if tick-by-tick execution is needed
+        /// (step mode active or breakpoints enabled).
+        pub fn needsTickDebug(self: *const Self) bool {
+            if (self.step_mode != .none) return true;
+            for (self.breakpoints[0..self.num_breakpoints]) |bp| {
+                if (bp.enabled) return true;
+            }
+            return false;
+        }
+
+        /// Call after each individual CPU tick.
+        /// Returns true if execution should stop.
+        pub fn tick(self: *Self, pins: Bus) bool {
+            if (pins & M1_MASK == M1_MASK) {
+                const pc = Z80.getAddr(pins);
+                self.cur_op_pc = pc;
+                self.history[self.history_pos] = pc;
+                self.history_pos +%= 1;
+                for (self.breakpoints[0..self.num_breakpoints]) |bp| {
+                    if (bp.enabled and bp.addr == pc) {
+                        self.stopped = true;
+                        self.step_mode = .none;
+                        return true;
+                    }
+                }
+                if (self.step_mode == .into) {
+                    self.stopped = true;
+                    self.step_mode = .none;
+                    return true;
+                }
+                if (self.step_mode == .over and pc == self.stepover_pc) {
+                    self.stopped = true;
+                    self.step_mode = .none;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        pub fn breakExec(self: *Self) void {
+            self.stopped = true;
+            self.step_mode = .none;
+        }
+
+        pub fn continueExec(self: *Self) void {
+            self.stopped = false;
+            self.step_mode = .none;
+        }
+
+        pub fn stepInto(self: *Self) void {
+            self.stopped = false;
+            self.step_mode = .into;
+        }
+
+        pub fn stepOver(self: *Self) void {
+            const opcode = self.read_cb(self.cur_op_pc, self.userdata);
+            const is_stepover_op = switch (opcode) {
+                0xCD, 0xDC, 0xFC, 0xD4, 0xC4, 0xF4, 0xEC, 0xE4, 0xCC, 0x10 => true,
+                else => false,
+            };
+            if (is_stepover_op) {
+                const res = z80dasm.op(self.cur_op_pc, self.read_cb, self.userdata);
+                self.stepover_pc = res.next_pc;
+                self.stopped = false;
+                self.step_mode = .over;
+            } else {
+                self.stepInto();
+            }
+        }
+
+        fn hasBreakpointAt(self: *const Self, addr: u16) bool {
+            for (self.breakpoints[0..self.num_breakpoints]) |bp| {
+                if (bp.addr == addr) return true;
+            }
+            return false;
+        }
+
+        fn isBreakpointEnabled(self: *const Self, addr: u16) bool {
+            for (self.breakpoints[0..self.num_breakpoints]) |bp| {
+                if (bp.addr == addr and bp.enabled) return true;
+            }
+            return false;
+        }
+
+        pub fn addBreakpoint(self: *Self, addr: u16) void {
+            if (self.num_breakpoints >= MAX_BREAKPOINTS) return;
+            for (self.breakpoints[0..self.num_breakpoints]) |*bp| {
+                if (bp.addr == addr) {
+                    bp.enabled = true;
+                    return;
+                }
+            }
+            self.breakpoints[self.num_breakpoints] = .{ .addr = addr, .enabled = true };
+            self.num_breakpoints += 1;
+        }
+
+        pub fn removeBreakpoint(self: *Self, addr: u16) void {
+            for (self.breakpoints[0..self.num_breakpoints], 0..) |bp, i| {
+                if (bp.addr == addr) {
+                    var j = i;
+                    while (j + 1 < self.num_breakpoints) : (j += 1) {
+                        self.breakpoints[j] = self.breakpoints[j + 1];
+                    }
+                    self.num_breakpoints -= 1;
+                    return;
+                }
+            }
+        }
+
+        pub fn toggleBreakpoint(self: *Self, addr: u16) void {
+            if (self.hasBreakpointAt(addr)) {
+                self.removeBreakpoint(addr);
+            } else {
+                self.addBreakpoint(addr);
+            }
+        }
+
+        fn rebuildDasm(self: *Self) void {
+            const look_back: u16 = 5 * 4;
+            const start = self.cur_op_pc -% look_back;
+            var pc: u16 = start;
+            var n: u8 = 0;
+            while (n < NUM_DBG_LINES) {
+                const op_addr = pc;
+                const res = z80dasm.op(pc, self.read_cb, self.userdata);
+                var line = DasmLine{
+                    .addr = op_addr,
+                    .num_bytes = res.num_bytes,
+                    .bytes = undefined,
+                    .mnemonic = res.mnemonic,
+                    .mnemonic_len = res.mnemonic_len,
+                };
+                for (0..res.num_bytes) |bi| {
+                    line.bytes[bi] = self.read_cb(op_addr +% @as(u16, @intCast(bi)), self.userdata);
+                }
+                self.dasm_lines[n] = line;
+                n += 1;
+                pc = res.next_pc;
+            }
+            self.dasm_num_lines = n;
+        }
+
+        fn drawButtons(self: *Self) void {
+            const stopped = self.stopped;
+            if (stopped) {
+                if (ig.igButton("Continue [F5]")) self.continueExec();
+            } else {
+                if (ig.igButton("Break [F5]")) self.breakExec();
+            }
+            ig.igSameLine();
+            if (!stopped) ig.igBeginDisabled(true);
+            if (ig.igButton("Step Over [F6]")) self.stepOver();
+            ig.igSameLine();
+            if (ig.igButton("Step Into [F7]")) self.stepInto();
+            if (!stopped) ig.igEndDisabled();
+        }
+
+        fn drawDisasm(self: *Self) void {
+            self.rebuildDasm();
+
+            const glyph_width = ig.igCalcTextSize("F").x;
+            const cell_width = 3.0 * glyph_width;
+
+            ig.igPushStyleVarImVec2(ig.ImGuiStyleVar_FramePadding, .{ .x = 0, .y = 0 });
+            ig.igPushStyleVarImVec2(ig.ImGuiStyleVar_ItemSpacing, .{ .x = 0, .y = 0 });
+
+            const avail = ig.igGetContentRegionAvail();
+            _ = ig.igBeginChild("##dbg_dasm", .{ .x = avail.x, .y = avail.y - 40 }, ig.ImGuiChildFlags_None, ig.ImGuiWindowFlags_None);
+
+            for (self.dasm_lines[0..self.dasm_num_lines]) |line| {
+                const is_cur = line.addr == self.cur_op_pc;
+                const has_bp = self.isBreakpointEnabled(line.addr);
+
+                if (is_cur) {
+                    ig.igPushStyleColor(ig.ImGuiCol_Text, 0xFF00FFFF);
+                } else if (has_bp) {
+                    ig.igPushStyleColor(ig.ImGuiCol_Text, 0xFF4040FF);
+                }
+
+                ig.igPushIDInt(@as(c_int, @intCast(line.addr)));
+
+                // Clickable indicator + address column
+                const indicator: []const u8 = if (has_bp) (if (is_cur) ">*" else " *") else (if (is_cur) "> " else "  ");
+                var row_buf: [16]u8 = undefined;
+                const row_s = std.fmt.bufPrint(&row_buf, "{s}{X:0>4}: \x00", .{ indicator, line.addr }) catch unreachable;
+                _ = row_s;
+                if (ig.igSelectable(&row_buf)) {
+                    self.toggleBreakpoint(line.addr);
+                }
+                ig.igSameLine();
+
+                // Bytes
+                const line_start_x = ig.igGetCursorPosX();
+                for (0..line.num_bytes) |bi| {
+                    ig.igSameLineEx(line_start_x + cell_width * @as(f32, @floatFromInt(bi)), 0);
+                    var byte_buf: [4]u8 = undefined;
+                    const bs = std.fmt.bufPrint(&byte_buf, "{X:0>2} \x00", .{line.bytes[bi]}) catch unreachable;
+                    _ = bs;
+                    ig.igTextUnformatted(&byte_buf);
+                }
+
+                // Mnemonic
+                ig.igSameLineEx(line_start_x + cell_width * 4 + glyph_width, 0);
+                var mn_buf: [z80dasm.MAX_MNEMONIC_LEN + 1]u8 = undefined;
+                @memcpy(mn_buf[0..line.mnemonic_len], line.mnemonic[0..line.mnemonic_len]);
+                mn_buf[line.mnemonic_len] = 0;
+                ig.igTextUnformatted(&mn_buf);
+
+                ig.igPopID();
+
+                if (is_cur or has_bp) ig.igPopStyleColor();
+
+                if (is_cur) ig.igSetScrollHereY(0.3);
+            }
+
+            ig.igEndChild();
+            ig.igPopStyleVarEx(2);
+        }
+
+        fn drawHistory(self: *Self) void {
+            if (!ig.igBegin("Execution History", &self.show_history, ig.ImGuiWindowFlags_None)) {
+                ig.igEnd();
+                return;
+            }
+            if (ig.igBeginListBox("##history", .{ .x = -1, .y = -1 })) {
+                const show: u8 = @min(64, self.history_pos);
+                var i: usize = @as(usize, self.history_pos);
+                var cnt: u8 = show;
+                while (cnt > 0) {
+                    cnt -= 1;
+                    if (i == 0) i = NUM_HISTORY;
+                    i -= 1;
+                    var buf: [8]u8 = undefined;
+                    const s = std.fmt.bufPrint(&buf, "{X:0>4}\x00", .{self.history[i]}) catch unreachable;
+                    _ = s;
+                    ig.igTextUnformatted(&buf);
+                }
+                ig.igEndListBox();
+            }
+            ig.igEnd();
+        }
+
+        fn handleKeys(self: *Self) void {
+            if (ig.igIsKeyPressedEx(ig.ImGuiKey_F5, false)) {
+                if (self.stopped) self.continueExec() else self.breakExec();
+            }
+            if (self.stopped) {
+                if (ig.igIsKeyPressedEx(ig.ImGuiKey_F6, false)) self.stepOver();
+                if (ig.igIsKeyPressedEx(ig.ImGuiKey_F7, false)) self.stepInto();
+                if (ig.igIsKeyPressedEx(ig.ImGuiKey_F9, false)) self.toggleBreakpoint(self.cur_op_pc);
+            }
+        }
+
+        pub fn draw(self: *Self, bus: Bus) void {
+            _ = bus;
+            if (self.open != self.last_open) self.last_open = self.open;
+            if (!self.open) return;
+
+            self.handleKeys();
+            if (self.show_history) self.drawHistory();
+
+            ig.igSetNextWindowPos(self.origin, ig.ImGuiCond_FirstUseEver);
+            ig.igSetNextWindowSize(self.size, ig.ImGuiCond_FirstUseEver);
+            if (ig.igBegin(self.title.ptr, &self.open, ig.ImGuiWindowFlags_None)) {
+                self.drawButtons();
+                ig.igSeparator();
+                self.drawDisasm();
+                ig.igSeparator();
+                var status_buf: [64]u8 = undefined;
+                const ss = std.fmt.bufPrint(&status_buf, "PC:{X:0>4}  {s}  BPs:{}\x00", .{
+                    self.cur_op_pc,
+                    if (self.stopped) @as([]const u8, "STOPPED") else @as([]const u8, "RUNNING"),
+                    self.num_breakpoints,
+                }) catch unreachable;
+                _ = ss;
+                ig.igTextUnformatted(&status_buf);
+                ig.igSameLine();
+                if (ig.igButton("History")) self.show_history = !self.show_history;
+                ig.igSameLine();
+                if (ig.igButton("Clear BPs")) self.num_breakpoints = 0;
+            }
+            ig.igEnd();
+        }
+
+        pub fn saveSettings(self: *Self, settings: *ui_settings.Settings) void {
+            _ = settings.add(self.title, self.open);
+        }
+
+        pub fn loadSettings(self: *Self, settings: *const ui_settings.Settings) void {
+            self.open = settings.isOpen(self.title);
+        }
+    };
+}


### PR DESCRIPTION
- src/chips/z80dasm.zig — stateless Z80 disassembler ported from z80dasm.h; callback-based memory access, handles all prefix bytes (CB/DD/ED/FD), all documented and undocumented instructions
- src/ui/ui_dasm.zig — standalone scrollable disassembler window (512 lines via ImGuiListClipper), navigation back-stack, jump-target arrow buttons for CALL/JP/JR/RST/DJNZ
- src/ui/ui_dbg.zig — comptime-parameterized CPU debugger (Type(.{.bus=..., .cpu=...})); step-into/step-over, up to 32 address breakpoints, 256-entry execution history ring buffer, F5/F6/F7/F9 hotkeys
- KC85 integration — execWithDebug() for per-tick stepping/breakpoint detection, Debug menu wired up, memRead callback